### PR TITLE
Viewpump 4.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Download](https://api.bintray.com/packages/b3nedikt/viewpump/viewpump/images/download.svg?version=4.0.4)](https://bintray.com/b3nedikt/viewpump/viewpump/4.0.4/link)
+[![Download](https://api.bintray.com/packages/b3nedikt/viewpump/viewpump/images/download.svg?version=4.0.5)](https://bintray.com/b3nedikt/viewpump/viewpump/4.0.5/link)
 
-# ViewPump 4.0.4
+# ViewPump 4.0.5
 
 View inflation you can intercept using an API of pre/post-inflation interceptors.
 
@@ -15,7 +15,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation 'dev.b3nedikt.viewpump:viewpump:4.0.4'
+    implementation 'dev.b3nedikt.viewpump:viewpump:4.0.5'
 }
 ```
 

--- a/viewpump/publish.gradle
+++ b/viewpump/publish.gradle
@@ -4,7 +4,7 @@ ext {
 
     publishedGroupId = 'dev.b3nedikt.viewpump'
     artifactId = 'viewpump'
-    libraryVersion = '4.0.4'
+    libraryVersion = '4.0.5'
 
     libraryName = 'ViewPump'
     libraryDescription = 'View inflation you can intercept. ViewPump installs a custom' +

--- a/viewpump/src/main/java/dev/b3nedikt/viewpump/ViewPumpAppCompatDelegate.kt
+++ b/viewpump/src/main/java/dev/b3nedikt/viewpump/ViewPumpAppCompatDelegate.kt
@@ -51,7 +51,15 @@ class ViewPumpAppCompatDelegate @JvmOverloads constructor(
                         attrs = attrs,
                         parent = parent,
                         fallbackViewCreator = {
-                            var view = super.createView(parent, name, context, attrs)
+                            var view = runCatching { super.createView(parent, name, context, attrs) }
+                                    .getOrElse {
+
+                                        // We only arrive here if the context passed into this
+                                        // method does not have a theme. This does only occur for
+                                        // views which are part of alert dialogs displayed when
+                                        // interacting with web views on API 22 and below.
+                                        super.createView(parent, name, baseContext, attrs)
+                                    }
 
                             if (view == null) {
                                 view = runCatching {


### PR DESCRIPTION
Fixed a crash on API 22 and below triggered by trying to create views which will be displayed in alert dialogs shown when interacting with web views. See: #10.